### PR TITLE
Introduce EitherT

### DIFF
--- a/editor.cabal
+++ b/editor.cabal
@@ -29,6 +29,7 @@ library
                      , syb-with-class
                      , template-haskell
                      , constraints
+                     , either
   default-language:    Haskell2010
 
 executable e

--- a/src/Modes.hs
+++ b/src/Modes.hs
@@ -144,11 +144,11 @@ generatePicture = do
   image <- modeOverlay
   return $ (generateView (0, 0) height $ lines src) `addToTop` image
 
-handleNextKeyEvent :: (MMonad z m, EditorMode z) => StateT (EitherT (State (BuildsOn z)) m) ()
+handleNextKeyEvent :: (MMonad z m, EditorMode z) => StateT (State z) (EitherT (State (BuildsOn z)) m) ()
 handleNextKeyEvent =
   nextKeyEvent >>= juggle handleKeyEvent
 
-juggle :: Monad m => (a -> s -> m (Either e s)) -> a -> StateT (EitherT e) m s
+juggle :: Monad m => (a -> s -> m (Either e s)) -> a -> StateT s (EitherT e m) ()
 juggle = fmap modifyT . (fmap . fmap) EitherT
 
 modifyT :: Monad m => (s -> m s) -> StateT s m ()

--- a/src/Modes.hs
+++ b/src/Modes.hs
@@ -144,7 +144,7 @@ generatePicture = do
   image <- modeOverlay
   return $ (generateView (0, 0) height $ lines src) `addToTop` image
 
-handleNextKeyEvent :: (MMonad z m, EditorMode z) => StateT (EitherT (State (BuildsOn z))) m ()
+handleNextKeyEvent :: (MMonad z m, EditorMode z) => StateT (EitherT (State (BuildsOn z)) m) ()
 handleNextKeyEvent =
   nextKeyEvent >>= juggle handleKeyEvent
 

--- a/src/Modes.hs
+++ b/src/Modes.hs
@@ -13,6 +13,7 @@ import Data.List (intercalate)
 import Control.Lens
 
 import Control.Applicative
+import Data.Void
 
 import Control.Monad (void)
 import Control.Monad.Reader (MonadReader, ask, runReaderT)

--- a/src/Modes.hs
+++ b/src/Modes.hs
@@ -17,7 +17,7 @@ import Data.Void
 
 import Control.Monad (void, forever)
 import Control.Monad.Reader (MonadReader, ask, runReaderT)
-import Control.Monad.State (execStateT, runStateT, StateT, MonadState, get, put, evalStateT)
+import Control.Monad.State (execStateT, runStateT, StateT(..), MonadState, get, put, evalStateT)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT)
 import Control.Monad (MonadPlus, mzero)

--- a/src/Modes.hs
+++ b/src/Modes.hs
@@ -15,9 +15,9 @@ import Control.Lens
 import Control.Applicative
 import Data.Void
 
-import Control.Monad (void)
+import Control.Monad (void, forever)
 import Control.Monad.Reader (MonadReader, ask, runReaderT)
-import Control.Monad.State (execStateT, runStateT, StateT, MonadState, get, put)
+import Control.Monad.State (execStateT, runStateT, StateT, MonadState, get, put, evalStateT)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Maybe (runMaybeT, MaybeT)
 import Control.Monad (MonadPlus, mzero)

--- a/src/Modes.hs
+++ b/src/Modes.hs
@@ -144,7 +144,7 @@ generatePicture = do
   return $ (generateView (0, 0) height $ lines src) `addToTop` image
 
 handleNextKeyEvent :: (MMonad z m, EditorMode z) => StateT (EitherT (State (BuildsOn z))) m ()
-handleNextKeyEvent = do
+handleNextKeyEvent =
   nextKeyEvent >>= juggle handleKeyEvent
 
 juggle :: Monad m => (a -> s -> m (Either e s)) -> a -> StateT (EitherT e) m s

--- a/stack.yaml
+++ b/stack.yaml
@@ -108,6 +108,7 @@ extra-deps:
 - vector-0.11.0.0
 - void-0.7.1
 - vty-5.7.1
+- either-4.4.1.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -109,6 +109,10 @@ extra-deps:
 - void-0.7.1
 - vty-5.7.1
 - either-4.4.1.1
+- MonadRandom-0.4.2.3
+- mmorph-1.0.6
+- monad-control-1.0.1.0
+- transformers-base-0.4.4
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Thus, recursion is replaced by `forever`, and the `StateT` blocks are unified.

`juggle`/`modifyT` are unnecessary if you give `handleKeyEvent` the type `MMonad z m => (Key, [Modifier]) -> StateT (EitherT (State (BuildsOn z))) m ()`, or even add the two layers to your mtl constraint list alias.

I'm not too good with all that stack/cabal/dependency stuff, so I'll leave adding the dependency to [either](https://hackage.haskell.org/package/either) to you.
